### PR TITLE
Expose raw logit weights to the API if request_logits=true

### DIFF
--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -31,6 +31,7 @@ pub async fn run(
     repetition_penalty: Option<f32>,
     watermark: bool,
     do_sample: bool,
+    return_logits: bool,
     client: ShardedClient,
 ) -> Result<(), crossterm::ErrorKind> {
     let parameters = NextTokenChooserParameters {
@@ -42,6 +43,7 @@ pub async fn run(
         seed: 0,
         repetition_penalty: repetition_penalty.unwrap_or(1.0),
         watermark,
+        return_logits: return_logits,
     };
 
     // Initialize terminal properties

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -93,6 +93,10 @@ struct Args {
     /// decoding strategies, for full doc refer to the `text-generation-server`
     #[clap(long, env)]
     do_sample: bool,
+
+    /// Enable logit array generation
+    #[clap(long, env)]
+    return_logits: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -117,6 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         watermark,
         do_sample,
         master_shard_uds_path,
+        return_logits,
     } = args;
 
     let batch_size = batch_size.unwrap_or(vec![1, 2, 4, 8, 16, 32]);
@@ -182,6 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 repetition_penalty,
                 watermark,
                 do_sample,
+                return_logits,
                 sharded_client,
             )
             .await

--- a/clients/python/text_generation/client.py
+++ b/clients/python/text_generation/client.py
@@ -66,6 +66,7 @@ class Client:
         best_of: Optional[int] = None,
         repetition_penalty: Optional[float] = None,
         return_full_text: bool = False,
+        return_logits: bool = False,
         seed: Optional[int] = None,
         stop_sequences: Optional[List[str]] = None,
         temperature: Optional[float] = None,
@@ -113,6 +114,8 @@ class Client:
                 Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226)
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
+            return_logits (`bool`):
+                Return a base64-encoded array of IEEE-754 32-bit float probabilities for all possible tokens into `logits`.
 
         Returns:
             Response: generated response
@@ -125,6 +128,7 @@ class Client:
             max_new_tokens=max_new_tokens,
             repetition_penalty=repetition_penalty,
             return_full_text=return_full_text,
+            return_logits=return_logits,
             seed=seed,
             stop=stop_sequences if stop_sequences is not None else [],
             temperature=temperature,
@@ -156,6 +160,7 @@ class Client:
         max_new_tokens: int = 20,
         repetition_penalty: Optional[float] = None,
         return_full_text: bool = False,
+        return_logits: bool = False,
         seed: Optional[int] = None,
         stop_sequences: Optional[List[str]] = None,
         temperature: Optional[float] = None,
@@ -180,6 +185,8 @@ class Client:
                 paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
             return_full_text (`bool`):
                 Whether to prepend the prompt to the generated text
+            return_logits (`bool`):
+                Return a base64-encoded array of IEEE-754 32-bit float probabilities for all possible tokens into `logits`.
             seed (`int`):
                 Random sampling seed
             stop_sequences (`List[str]`):
@@ -211,6 +218,7 @@ class Client:
             max_new_tokens=max_new_tokens,
             repetition_penalty=repetition_penalty,
             return_full_text=return_full_text,
+            return_logits=return_logits,
             seed=seed,
             stop=stop_sequences if stop_sequences is not None else [],
             temperature=temperature,
@@ -308,6 +316,7 @@ class AsyncClient:
         best_of: Optional[int] = None,
         repetition_penalty: Optional[float] = None,
         return_full_text: bool = False,
+        return_logits: bool = False,
         seed: Optional[int] = None,
         stop_sequences: Optional[List[str]] = None,
         temperature: Optional[float] = None,
@@ -335,6 +344,8 @@ class AsyncClient:
                 paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
             return_full_text (`bool`):
                 Whether to prepend the prompt to the generated text
+            return_logits (`bool`):
+                Return a base64-encoded array of IEEE-754 32-bit float probabilities for all possible tokens into `logits`.
             seed (`int`):
                 Random sampling seed
             stop_sequences (`List[str]`):
@@ -355,6 +366,8 @@ class AsyncClient:
                 Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226)
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
+            return_logits (`bool`):
+                Return a base64-encoded array of IEEE-754 32-bit float probabilities for all possible tokens into `logits`.
 
         Returns:
             Response: generated response
@@ -368,6 +381,7 @@ class AsyncClient:
             max_new_tokens=max_new_tokens,
             repetition_penalty=repetition_penalty,
             return_full_text=return_full_text,
+            return_logits=return_logits,
             seed=seed,
             stop=stop_sequences if stop_sequences is not None else [],
             temperature=temperature,
@@ -396,6 +410,7 @@ class AsyncClient:
         max_new_tokens: int = 20,
         repetition_penalty: Optional[float] = None,
         return_full_text: bool = False,
+        return_logits: bool = False,
         seed: Optional[int] = None,
         stop_sequences: Optional[List[str]] = None,
         temperature: Optional[float] = None,
@@ -420,6 +435,8 @@ class AsyncClient:
                 paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
             return_full_text (`bool`):
                 Whether to prepend the prompt to the generated text
+            return_logits (`bool`):
+                Return a base64-encoded array of IEEE-754 32-bit float probabilities for all possible tokens into `logits`.
             seed (`int`):
                 Random sampling seed
             stop_sequences (`List[str]`):
@@ -451,6 +468,7 @@ class AsyncClient:
             max_new_tokens=max_new_tokens,
             repetition_penalty=repetition_penalty,
             return_full_text=return_full_text,
+            return_logits=return_logits,
             seed=seed,
             stop=stop_sequences if stop_sequences is not None else [],
             temperature=temperature,

--- a/clients/python/text_generation/types.py
+++ b/clients/python/text_generation/types.py
@@ -15,6 +15,8 @@ class Parameters(BaseModel):
     repetition_penalty: Optional[float] = None
     # Whether to prepend the prompt to the generated text
     return_full_text: bool = False
+    # Return a base64-encoded array of IEEE-754 32-bit float probabilities for all possible tokens into `logits`.
+    return_logits: bool = False
     # Stop generating tokens if a member of `stop_sequences` is generated
     stop: List[str] = []
     # Random sampling seed

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -524,6 +524,10 @@
             "example": false,
             "nullable": true
           },
+          "return_logits": {
+            "type": "boolean",
+            "default": "false"
+          },
           "seed": {
             "type": "integer",
             "format": "int64",
@@ -835,6 +839,13 @@
           "text": {
             "type": "string",
             "example": "test"
+          },
+          "logits": {
+            "type": "array",
+            "items": {
+              "type": "float"
+            },
+            "nullable": true
           }
         }
       }

--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -66,6 +66,8 @@ message NextTokenChooserParameters {
     float repetition_penalty = 7;
     /// token watermarking using "A Watermark for Large Language Models"
     bool watermark = 8;
+    /// True if you want logits returned as a byte array of float32 probabilities
+    bool return_logits = 9;
 }
 
 message StoppingCriteriaParameters {
@@ -156,6 +158,8 @@ message Generation {
     bool token_is_special = 6;
     /// Complete generated text
     optional GeneratedText generated_text = 7;
+    /// Logit weights binary
+    optional bytes logit_binary = 8;
 }
 
 message FilterBatchRequest {
@@ -181,6 +185,8 @@ message PrefillResponse {
     repeated Generation generations = 1;
     /// Next batch (cached)
     optional CachedBatch batch = 2;
+    /// Logit tokens
+    optional string logit_tokens = 3;
 }
 
 message DecodeRequest {

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -124,6 +124,7 @@ impl Client {
                     seed: 0,
                     repetition_penalty: 1.2,
                     watermark: true,
+                    return_logits: false,
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: 2,

--- a/router/src/health.rs
+++ b/router/src/health.rs
@@ -44,6 +44,7 @@ impl Health {
                     seed: 0,
                     repetition_penalty: 1.0,
                     watermark: false,
+                    return_logits: false,
                 }),
                 stopping_parameters: Some(StoppingCriteriaParameters {
                     max_new_tokens: 1,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -125,6 +125,9 @@ pub(crate) struct GenerateParameters {
     #[schema(default = "true")]
     pub details: bool,
     #[serde(default)]
+    #[schema(default = "false")]
+    pub return_logits: bool,
+    #[serde(default)]
     #[schema(default = "true")]
     pub decoder_input_details: bool,
     #[serde(default)]
@@ -156,6 +159,7 @@ fn default_parameters() -> GenerateParameters {
         truncate: None,
         watermark: false,
         details: false,
+        return_logits: false,
         decoder_input_details: false,
         seed: None,
     }
@@ -209,6 +213,8 @@ pub struct Token {
     logprob: f32,
     #[schema(example = "false")]
     special: bool,
+    #[schema(nullable = true)]
+    logits: Option<String>,
 }
 
 #[derive(Serialize, ToSchema)]

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -322,6 +322,7 @@ mod tests {
                     seed: 0,
                     repetition_penalty: 0.0,
                     watermark: false,
+                    return_logits: false,
                 },
                 stopping_parameters: StoppingCriteriaParameters {
                     ignore_eos_token: false,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -159,6 +159,7 @@ async fn generate(
     if req.0.parameters.return_full_text.unwrap_or(false) {
         add_prompt = Some(req.0.inputs.clone());
     }
+    // let return_logits = req.0.parameters.return_logits;
 
     let details = req.0.parameters.details || req.0.parameters.decoder_input_details;
 

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -247,6 +247,7 @@ impl Validation {
             do_sample,
             seed,
             watermark,
+            return_logits: request.parameters.return_logits,
         };
         let stopping_parameters = StoppingCriteriaParameters {
             max_new_tokens,

--- a/server/text_generation_server/models/causal_lm.py
+++ b/server/text_generation_server/models/causal_lm.py
@@ -645,6 +645,7 @@ class CausalLM(Model):
                     next_token_text,
                     next_token_id_squeezed.item() in self.all_special_ids,
                     generated_text,
+                    None, # logits.detach()[-1], #logits_logprob[:50].detach()
                 )
 
                 generations.append(generation)

--- a/server/text_generation_server/models/flash_causal_lm.py
+++ b/server/text_generation_server/models/flash_causal_lm.py
@@ -933,6 +933,7 @@ class FlashCausalLM(Model):
             batch.next_token_chooser.seeds,
             next_token_ids,
             next_token_logprobs,
+            next_token_logits.type(torch.FloatTensor).detach().cpu(),
         )
 
         # For each member of the batch
@@ -947,6 +948,7 @@ class FlashCausalLM(Model):
             seed,
             next_token_id,
             next_token_logprob,
+            next_token_logit,
         ) in enumerate(iterator):
             # Append next token to all tokens
             all_input_ids.append(next_token_id)
@@ -1017,6 +1019,7 @@ class FlashCausalLM(Model):
                     next_token_text,
                     next_token_id in self.all_special_ids,
                     generated_text,
+                    next_token_logit if request.parameters.return_logits else None,
                 )
 
                 generations.append(generation)

--- a/server/text_generation_server/models/seq2seq_lm.py
+++ b/server/text_generation_server/models/seq2seq_lm.py
@@ -706,6 +706,7 @@ class Seq2SeqLM(Model):
                     next_token_text,
                     next_token_id_squeezed.item() in self.all_special_ids,
                     generated_text,
+                    None, # logits.detach()[-1], # logits_logprob[:50].detach(),
                 )
 
                 generations.append(generation)


### PR DESCRIPTION
# What does this PR do?

Adds a new input boolean parameter `return_logits`. If true, each Generation will contain the base64 of the binary float32 array of logit weights inside the Token's details.

I have tested performance and this extra output data does not add any measurable performance overhead.

It would be useful to have a test application on top of this API to demonstrate its usefulness.